### PR TITLE
Improve suggestion hover style

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -403,7 +403,7 @@ function DropdownItem({
           !isDisabled
             ? item.type && invalidTypes.includes(item.type) && !!customInvalidTagMessage
               ? undefined
-              : item.callback ?? onClick.bind(null, item.value, item)
+              : (item.callback ?? onClick.bind(null, item.value, item))
             : undefined
         }
         ref={element => item.active && element?.scrollIntoView?.({block: 'nearest'})}
@@ -558,6 +558,11 @@ const SearchListItem = styled('li')<{isChild?: boolean; isDisabled?: boolean}>`
         &:hover,
         &.active {
           background: ${p.theme.hover};
+          border-top-color: transparent;
+        }
+
+        &:hover + li {
+          border-top-color: transparent;
         }
       `;
     }

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -254,6 +254,7 @@ const Suggestion = styled('li')`
 
   &:hover {
     cursor: pointer;
+    border-bottom-color: transparent;
   }
 
   &:hover .data-actions-wrapper {


### PR DESCRIPTION
## Summary
- tweak issue list suggestion item style so divider disappears on hover
- make search dropdown items hide their divider on hover

## Testing
- `npx prettier static/app/components/smartSearchBar/searchDropdown.tsx static/app/views/issueList/addViewPage.tsx --check`